### PR TITLE
adds force option for compress-archive

### DIFF
--- a/buildAndPushReqExecArtifacts.ps1
+++ b/buildAndPushReqExecArtifacts.ps1
@@ -57,7 +57,7 @@ Function build_reqExec() {
 
 Function push_to_s3() {
   echo "Pushing to S3..."
-  Compress-Archive -Path $REQ_EXEC_BINARY_DIR -DestinationPath $REQ_EXEC_BINARY_ZIP
+  Compress-Archive -Force -Path $REQ_EXEC_BINARY_DIR -DestinationPath $REQ_EXEC_BINARY_ZIP
   aws s3 cp --acl public-read "$REQ_EXEC_BINARY_ZIP" "$S3_BUCKET_BINARY_DIR"
 }
 


### PR DESCRIPTION
https://github.com/Shippable/x86_64.WindowsServer_2016.prep/issues/4

reqExec gets packaged and pushed to S3 after merging https://github.com/Shippable/x86_64.WindowsServer_2016.prep/pull/5

But we missed an `-Force` option which fails the job ( if the zip file is already present in the location ) with 
```
Compress-Archive : The archive file
C:\Users\ADMINI~1\AppData\Local\Temp\3\reqExec-master-x86_64-WindowsServer_2016.zip already exists. Use the -Update
parameter to update the existing archive file or use the -Force parameter to overwrite the existing archive file.
At C:\Users\Administrator\b.ps1:60 char:3
+   Compress-Archive -Path $REQ_EXEC_BINARY_DIR -DestinationPath $REQ_E ...
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (C:\Users\ADMINI...Server_2016.zip:String) [Compress-Archive], IOExcept
   ion
    + FullyQualifiedErrorId : ArchiveFileExists,Compress-Archive
```

So, adding it to overwrite the zip file, if it already exists.