### PR TITLE
zips the contents instead of directory

### DIFF
--- a/buildAndPushReqExecArtifacts.ps1
+++ b/buildAndPushReqExecArtifacts.ps1
@@ -57,7 +57,7 @@ Function build_reqExec() {
 
 Function push_to_s3() {
   echo "Pushing to S3..."
-  Compress-Archive -Force -Path $REQ_EXEC_BINARY_DIR -DestinationPath $REQ_EXEC_BINARY_ZIP
+  Compress-Archive -Force -Path "$REQ_EXEC_BINARY_DIR\*" -DestinationPath $REQ_EXEC_BINARY_ZIP
   aws s3 cp --acl public-read "$REQ_EXEC_BINARY_ZIP" "$S3_BUCKET_BINARY_DIR"
 }
 


### PR DESCRIPTION
https://github.com/Shippable/x86_64.WindowsServer_2016.prep/issues/4

Currently when we extract, we get `reqExec/dist/main/main.exe` 

But, what we expect is `dist/main/main.exe`

Hence making this change.